### PR TITLE
Tabbar Padding Option

### DIFF
--- a/layout/mstab.lua
+++ b/layout/mstab.lua
@@ -7,6 +7,7 @@ local mylayout = {}
 
 mylayout.name = "mstab"
 
+local tabbar_padding = beautiful.mstab_bar_padding or 0
 local tabbar_height = beautiful.mstab_bar_height or 40
 local corner_radius = beautiful.mstab_corner_width or beautiful.corner_radius or 0
 local tabbar_font = beautiful.mstab_font or beautiful.font or "Monospace 8"
@@ -87,10 +88,10 @@ function update_tabbar(clients, t, top_idx, area, master_area_width, slave_area_
     s.tabbar.x = area.x + master_area_width + t.gap
     s.tabbar.y = area.y + t.gap
     s.tabbar.width  = slave_area_width -  2*t.gap
-    s.tabbar.height = tabbar_height - 2*t.gap
+    s.tabbar.height = tabbar_height
 
     if tabbar_orientation == "bottom" then 
-        s.tabbar.y = area.y + area.height - tabbar_height + t.gap
+        s.tabbar.y = area.y + area.height - tabbar_height - t.gap
     end 
 
     -- update clientlist 
@@ -161,7 +162,7 @@ function mylayout.arrange(p)
             x = area.x + master_area_width + slave_area_width/4,
             y = area.y + tabbar_height + area.height/4,
             width = slave_area_width/2,
-            height = area.height/4 - tabbar_height,
+            height = area.height/4 - tabbar_height - tabbar_padding,
          }
          if idx == t.top_idx then 
              g.width = slave_area_width
@@ -169,7 +170,7 @@ function mylayout.arrange(p)
              g.x = area.x + master_area_width
              g.y = area.y
              if tabbar_orientation == "top" then 
-                 g.y = g.y + tabbar_height
+                 g.y = g.y + tabbar_height + tabbar_padding
              else
                  g.y = g.y
              end 

--- a/layout/mstab.lua
+++ b/layout/mstab.lua
@@ -162,11 +162,11 @@ function mylayout.arrange(p)
             x = area.x + master_area_width + slave_area_width/4,
             y = area.y + tabbar_height + area.height/4,
             width = slave_area_width/2,
-            height = area.height/4 - tabbar_height - tabbar_padding,
+            height = area.height/4 - tabbar_height
          }
          if idx == t.top_idx then 
              g.width = slave_area_width
-             g.height = area.height - tabbar_height
+             g.height = area.height - tabbar_height - tabbar_padding
              g.x = area.x + master_area_width
              g.y = area.y
              if tabbar_orientation == "top" then 


### PR DESCRIPTION
I changed how padding/height works in tabbars. Basically, I added a padding option to adjust the space between the tabbar and client.

(Clients also change size to count for padding)

* 0 padding, top
![image](https://user-images.githubusercontent.com/33443763/96824239-24276e80-13e3-11eb-9001-b1950bfbf026.png)

* 20 padding, top
![image](https://user-images.githubusercontent.com/33443763/96829024-8f763e00-13ed-11eb-8664-f243ca2ad6bc.png)

* 0 padding, bottom
![image](https://user-images.githubusercontent.com/33443763/96829055-a74dc200-13ed-11eb-8651-f26baa0e5198.png)

* 20 padding, bottom
![image](https://user-images.githubusercontent.com/33443763/96829108-b92f6500-13ed-11eb-9cf1-7476cc84c35a.png)

