### PR TITLE
Deal with playerctl signal module leaks

### DIFF
--- a/signal/playerctl.lua
+++ b/signal/playerctl.lua
@@ -117,4 +117,12 @@ local enable = function()
     emit_player_info()
 end
 
-return {enable = enable}
+local disable = function()
+    awful.spawn.with_shell("pkill --full --uid " .. os.getenv("USER") ..
+                               " '^playerctl status -F'")
+
+    awful.spawn.with_shell("pkill --full --uid " .. os.getenv("USER") ..
+                               " '^playerctl metadata --format'")
+end
+
+return {enable = enable, disable = disable}

--- a/signal/playerctl.lua
+++ b/signal/playerctl.lua
@@ -34,6 +34,7 @@ local function emit_player_status()
                 awesome.emit_signal("bling::playerctl::status", playing)
             end
         })
+        collectgarbage("collect")
     end)
 end
 
@@ -79,6 +80,7 @@ echo "$tmp_cover_path"
                 end
             end
         end)
+        collectgarbage("collect")
     end)
 
     -- Follow title
@@ -103,8 +105,10 @@ echo "$tmp_cover_path"
                         awesome.emit_signal("bling::playerctl::player_stopped")
                     end
                 end)
+                collectgarbage("collect")
             end
         })
+        collectgarbage("collect")
     end)
 end
 


### PR DESCRIPTION
This PR should deal with the leaks as described in #24. This seems to be a problem with the GC and the `awful.spawn.easy_async` commands, as said [here](https://github.com/awesomeWM/awesome/issues/1490).

- [x] Add a disable function
- [x] Add GC call