### PR TITLE
moved sync functions to helpers

### DIFF
--- a/helpers/client.lua
+++ b/helpers/client.lua
@@ -29,6 +29,21 @@ function _client.turn_on(c)
     client.focus = c
 end
 
+--- Sync two clients
+--
+-- @param to_c The client to which to write all properties
+-- @param from_c The client from which to read all properties
+function _client.sync(to_c, from_c)
+    if not from_c or not to_c then return end
+    if not from_c.valid or not to_c.valid then return end
+    if from_c.modal then return end
+    to_c.floating = from_c.floating
+    to_c.maximized = from_c.maximized
+    to_c.above = from_c.above
+    to_c.below = from_c.below
+    to_c:geometry(from_c:geometry())
+    -- TODO: Should also copy over the position in a tiling layout
+end
 
 
 return _client

--- a/module/tabbed.lua
+++ b/module/tabbed.lua
@@ -20,16 +20,6 @@ local bar_style = beautiful.tabbar_style or "default"
 local bar = require(tostring(...):match(".*bling") .. ".widget.tabbar." ..
                         bar_style)
 
-local function copy_size(c, parent_client)
-    if not c or not parent_client then return end
-    if not c.valid or not parent_client.valid then return end
-    c.floating = parent_client.floating
-    c.x = parent_client.x
-    c.y = parent_client.y
-    c.width = parent_client.width
-    c.height = parent_client.height
-end
-
 tabbed = {}
 
 -- used to change focused tab relative to the currently focused one 
@@ -61,7 +51,7 @@ end
 -- adds a client to a given tabobj
 tabbed.add = function(c, tabobj)
     if c.bling_tabbed then return end
-    copy_size(c, tabobj.clients[tabobj.focused_idx])
+    helpers.client.sync(c, tabobj.clients[tabobj.focused_idx])
     tabobj.clients[#tabobj.clients + 1] = c
     tabobj.focused_idx = #tabobj.clients
     -- calls update even though switch_to calls update again
@@ -132,7 +122,7 @@ tabbed.update = function(tabobj)
     for idx, c in ipairs(tabobj.clients) do
         if c.valid then
             c.bling_tabbed = tabobj
-            copy_size(c, currently_focused_c)
+            helpers.client.sync(c, currently_focused_c)
             -- the following handles killing a client while the client is tabbed
             c:connect_signal("unmanage", function(c) tabbed.remove(c) end)
         end
@@ -154,7 +144,7 @@ tabbed.switch_to = function(tabobj, new_idx)
             if old_focused_c and old_focused_c.valid then
                 c:swap(old_focused_c)
             end
-            copy_size(c, old_focused_c)
+            helpers.client.sync(c, old_focused_c)
         end
     end
     tabbed.update(tabobj)

--- a/module/window_swallowing.lua
+++ b/module/window_swallowing.lua
@@ -14,23 +14,6 @@ local window_swallowing_activated = false
 local dont_swallow_classname_list = beautiful.dont_swallow_classname_list or {"firefox", "Gimp", "Google-chrome"} 
 local activate_dont_swallow_filter = beautiful.dont_swallow_filter_activated or true
 
--- makes c the same size and position as parent_client
-local function copy_size(c, parent_client)
-    if not c or not parent_client then
-        return
-    end
-    if not c.valid or not parent_client.valid then
-        return
-    end
-    c.floating = parent_client.floating
-    c.x = parent_client.x;
-    c.y = parent_client.y;
-    c.width = parent_client.width;
-    c.height = parent_client.height;
-    -- TODO that function should also support "copying" the 
-    -- index of the parent_client to the new c 
-end
-
 -- checks if client classname matches with any entry of the dont-swallow-list
 local function check_if_swallow(c) 
     if not activate_dont_swallow_filter then 
@@ -59,10 +42,10 @@ local function manage_clientspawn(c)
 
         c:connect_signal("unmanage", function()
             helpers.client.turn_on(parent_client)
-            copy_size(parent_client, c)
+            helpers.client.sync(parent_client, c)
         end)
 
-        copy_size(c, parent_client)
+        helpers.client.sync(c, parent_client)
         helpers.client.turn_off(parent_client)
 
     end


### PR DESCRIPTION
There has been more or less the same syncing function in the tabbed and the window_swallowing module so I moved them into the client helper functions. Since these modules are a little more complex, it would be cool if someone can take a look before I merge.