### PR TITLE
Remove awesome dependency

### DIFF
--- a/bling-scm-1.rockspec
+++ b/bling-scm-1.rockspec
@@ -19,7 +19,6 @@ description = {
 
 dependencies = {
    "lua >= 5.1",
-   "awesome >= 4.0",
 }
 
 build = {

--- a/bling-scm-2.rockspec
+++ b/bling-scm-2.rockspec
@@ -1,5 +1,5 @@
 package = "bling"
-version = "scm-1"
+version = "scm-2"
 
 source = {
    url = "https://github.com/Nooo37/bling",


### PR DESCRIPTION
Because AwesomeWM is not distributed through LuaRocks, having a dependency on awesome results in the rock being uninstallable.