### PR TITLE
(docs) fix syntax errors in task preview example

### DIFF
--- a/docs/widgets/task_preview.md
+++ b/docs/widgets/task_preview.md
@@ -49,9 +49,9 @@ bling.widget.task_preview.enable {
                     widget = awful.widget.clienticon, -- The client icon
                 },
                 {
-                    id = 'name_role' -- The client name / title
+                    id = 'name_role', -- The client name / title
                     widget = wibox.widget.textbox,
-                }
+                },
                 layout = wibox.layout.flex.horizontal
             },
             widget = wibox.container.margin,


### PR DESCRIPTION
There were a few missing commas in the task preview example [here](https://blingcorp.github.io/bling/#/widgets/task_preview), which would break the config.