### PR TITLE
Added new funtionality to flash_focus

### DIFF
--- a/module/flash_focus.lua
+++ b/module/flash_focus.lua
@@ -2,10 +2,26 @@ local gears = require("gears")
 local beautiful = require("beautiful")
 
 local op = beautiful.flash_focus_start_opacity or 0.6
-local stp = beautiful.flash_focus_step or 0.01
+local stp = beautiful.flash_focus_step or 0.02
+local transparency_rules = beautiful.flash_focus_transparency_rules or {}
+
+local function search_rules(c)
+    local found = false
+    local num = 0
+    for _, v in pairs(transparency_rules) do
+        if string.match(v, c.class) or string.match(v, c.name) or string.match(v, c.type) then
+            found = true
+            num = v:match("%d+")
+            break
+        end
+    end
+    return found, num
+end
+
 
 local flashfocus = function(c)
     if c and #c.screen.clients > 1 then
+        local found, num = search_rules(c)
         c.opacity = op
         local q = op
         local g = gears.timer({
@@ -18,12 +34,22 @@ local flashfocus = function(c)
             if not c.valid then
                 return
             end
-            if q >= 1 then
-                c.opacity = 1
-                g:stop()
+            if found then
+                if q >= (tonumber(num)/100) then
+                    c.opacity = (tonumber(num)/100)
+                    g:stop()
+                else
+                    c.opacity = q
+                    q = q + stp
+                end
             else
-                c.opacity = q
-                q = q + stp
+                if q >= 1 then
+                    c.opacity = 1
+                    g:stop()
+                else
+                    c.opacity = q
+                    q = q + stp
+                end
             end
         end)
     end

--- a/theme-var-template.lua
+++ b/theme-var-template.lua
@@ -13,6 +13,7 @@ theme.dont_swallow_filter_activated = true -- whether the filter above should be
 -- flash focus
 theme.flash_focus_start_opacity = 0.6 -- the starting opacity
 theme.flash_focus_step = 0.01 -- the step of animation
+theme.flash_focus_transparency_rules = {"Code:70", "Alacrity:80"} -- a list of opacity rules for flash focus to use
 
 -- playerctl signal
 theme.playerctl_backend = "playerctl_cli" -- backend to use


### PR DESCRIPTION
- flash_focus now accepts a table so that each window can have its own ending opacity. Simply configure the theme variable flash_focus_transparency_rules = {}