### PR TITLE
Fix for Flatpak apps and add Tym terminal lookup

### DIFF
--- a/widget/app_launcher/init.lua
+++ b/widget/app_launcher/init.lua
@@ -593,7 +593,8 @@ local function generate_apps(self)
         if app.should_show(app) then
             local name = app_info.get_name(app)
             local commandline = app_info.get_commandline(app)
-            local executable = app_info.get_executable(app)
+            local executable = app:get_string("Exec")
+            executable = executable:match("^(.-)%%") or executable
             local icon = icon_theme:get_gicon_path(app_info.get_icon(app))
 
             -- Check if this app should be skipped, depanding on the skip_names / skip_commands table

--- a/widget/app_launcher/init.lua
+++ b/widget/app_launcher/init.lua
@@ -25,7 +25,8 @@ local terminal_commands_lookup =
     alacritty = "alacritty -e",
     termite = "termite -e",
     rxvt = "rxvt -e",
-    terminator = "terminator -e"
+    terminator = "terminator -e",
+    tym = "tym --"
 }
 
 local function string_levenshtein(str1, str2)


### PR DESCRIPTION
Before the get_executable would only return the string "flatpak" from the Exec line while the new function returns the whole string.

I also added Tym terminal to the lookup.

I know https://github.com/BlingCorp/bling/pull/198 fixes this but that PR has been in works for ages now.